### PR TITLE
Fix postinstall execution on Node 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
   - node
+  - '10'
   - '8'
   - '6'

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "tsc -p tsconfig.json",
     "watch": "tsc -p tsconfig.json --watch",
     "prepublish": "tsc -p tsconfig.json",
-    "test": "npm run build && jasmine **/*_spec.js"
+    "test": "npm run build && jasmine src/**/*_spec.js"
   },
   "keywords": [
     "schematics"

--- a/src/files/ng-add-pug-loader.js
+++ b/src/files/ng-add-pug-loader.js
@@ -7,16 +7,21 @@ const commonCliConfig = '__COMMON_CLI_CONFIG_PATH__';
 const pugRule = '__PUG_RULE__';
 
 fs.readFile(commonCliConfig, (err, data) => {
-  if (err) { throw err; }
+  if (err) throw err;
 
   const configText = data.toString();
   // make sure we don't add the rule if it already exists
-  if (configText.indexOf(pugRule) > -1) { return; }
+  if (configText.indexOf(pugRule) > -1) return;
 
   // Insert the pug webpack rule
   const position = configText.indexOf('rules: [') + 8;
   const output = [configText.slice(0, position), pugRule, configText.slice(position)].join('');
+  
   const file = fs.openSync(commonCliConfig, 'r+');
-  fs.writeFile(file, output);
-  fs.close(file);
+  fs.writeFile(file, output, error => {
+    if (error)
+      console.error("An error occurred while overwriting Angular CLI's Webpack config");
+
+    fs.close(file, () => {});
+  });
 });


### PR DESCRIPTION
According to issue #5, `ng-add-pug-loader.js` currently fails on Node 10 (https://github.com/danguilherme/ng-cli-pug-loader/issues/5#issuecomment-408723962).

Before merging this PR, it would be great to find a way to automatically test this.